### PR TITLE
docs(readme): Make middleware example runnable

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,9 +236,16 @@ router.all((request) => {
   return NextResponse.next();
 });
 
-export function middleware(request: NextRequest) {
-  return NextResponse.redirect(new URL("/about-2", request.url));
-}
+export default router.handler({
+  onError(err) {
+    return new NextResponse(JSON.stringify({ error: (err as Error).message }), {
+      status: 500,
+      headers: {
+        "content-type": "application/json",
+      },
+    })
+  },
+})
 ```
 
 ## API


### PR DESCRIPTION
The current example wasn't runnable as is, as there was no export of the middleware router. With this update things will execute properly. 